### PR TITLE
Confluence Pages with page property reports and labels

### DIFF
--- a/scripts/atcutils.py
+++ b/scripts/atcutils.py
@@ -316,6 +316,10 @@ class ATCutils:
                 }
             }
         }
+
+        if "metadata" in data:
+            dict_payload["metadata"] = data["metadata"]
+
         payload = json.dumps(dict_payload)
 
         response = requests.request(

--- a/scripts/init_confluence.py
+++ b/scripts/init_confluence.py
@@ -51,6 +51,11 @@ def main(c_auth=None):
               "Mitigation Systems", "Mitigation Policies",
               "Hardening Policies", "Use Cases"]
 
+    page_contents = {
+        "Customers": "<p><ac:structured-macro ac:name=\"detailssummary\" ac:schema-version=\"2\" ><ac:parameter ac:name=\"cql\">label = &quot;atc_customer&quot; and space = currentSpace()</ac:parameter></ac:structured-macro></p>",
+        "Use Cases": "<p><ac:structured-macro ac:name=\"detailssummary\" ac:schema-version=\"2\" ><ac:parameter ac:name=\"cql\">label = &quot;atc_usecases&quot; and space = currentSpace()</ac:parameter></ac:structured-macro></p>",
+    }
+
     for page in pages:
         print("Creating %s..." % page)
         data = {
@@ -59,7 +64,7 @@ def main(c_auth=None):
             "parentid": str(ATCutils.confluence_get_page_id(
                 url, auth, confluence_space_name,
                 confluence_name_of_root_directory)),
-            "confluencecontent": content,
+            "confluencecontent": page_contents.get(page, content),
         }
 
         if not ATCutils.push_to_confluence(data, url, auth):

--- a/scripts/populateconfluence.py
+++ b/scripts/populateconfluence.py
@@ -302,7 +302,12 @@ class PopulateConfluence:
                     "parentid": str(ATCutils.confluence_get_page_id(
                         self.apipath, self.auth, self.space,
                         "Customers")),
-                    "confluencecontent": cu.content
+                    "confluencecontent": cu.content,
+                    "metadata": {
+                        "labels": [{
+                        "name": "atc_customer"
+                        }]
+                    }
                 }
 
                 res = ATCutils.push_to_confluence(confluence_data, self.apipath,
@@ -340,7 +345,12 @@ class PopulateConfluence:
                     "parentid": str(ATCutils.confluence_get_page_id(
                         self.apipath, self.auth, self.space,
                         "Use Cases")),
-                    "confluencecontent": uc.content
+                    "confluencecontent": uc.content,
+                    "metadata": {
+                        "labels": [{
+                        "name": "atc_usecases"
+                        }]
+                    }
                 }
 
                 res = ATCutils.push_to_confluence(confluence_data, self.apipath,


### PR DESCRIPTION
This change will:
1. Init Base Pages (Customers, Detection Rules, etc.) including page property macros
  - Currently only for Customers as an example
  - Page Property Report is limited to page labels
2. Label each Customer Page

Benefit: A nice 'overview' page for each bucket.