### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,17 @@ RUN apk update; \
     python3 \
     python3-dev \
     py-pip \
-    bash; \
-    pip3 install -r requirements.txt; \
-    apk del python3-dev; \
-    rm -rf /var/cache/apk/* ; \
+    gcc \
+    musl-dev \
+    bash;
+
+RUN pip3 install -r requirements.txt;
+    
+RUN apk del python3-dev \
+    gcc \
+    musl-dev;
+
+RUN rm -rf /var/cache/apk/* ; \
     rm -rf Atomic_Threat_Coverage;
+
 CMD /app/docker-entrypoint.sh


### PR DESCRIPTION
As an answer to Issue #222, I modified the Dockerfile because we forgot some dependencies and it makes container build crash.

So I added some lines in the Dockerfile in order to install gcc and musl-dev to build python requirements.
Then I delete them since we don't need it inside the container.

Now all the requirements are given to build without any error. So the usual ```docker build . -t atc``` should work.